### PR TITLE
fix: force extractNativeLibs for ggml backend discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.1.2
+
+### Fixed
+
+- Fixed native backend loading failing in consumer apps on Android 6+ (API 23+).
+  Root cause: `extractNativeLibs` defaults to `false`, so `.so` files stay inside
+  the APK and are never extracted to the `nativeLibraryDir` on disk. Added
+  `android:extractNativeLibs="true"` to the plugin manifest so it merges into all
+  consumer apps automatically.
+- Improved backend loading with a 4-step fallback chain: directory scan → system
+  default discovery → filename-only load → full-path load, with `dlerror()` logging
+  for diagnostics.
+
 ## 0.1.1
 
 ### Fixed

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.theorangeshade.onenm_local_llm">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+  <!-- Force native lib extraction so ggml can discover backend .so files
+       via directory scanning at runtime (required on Android 6+ where
+       extractNativeLibs defaults to false). -->
+  <application android:extractNativeLibs="true" />
 </manifest>

--- a/android/src/main/cpp/onenm_bridge.cpp
+++ b/android/src/main/cpp/onenm_bridge.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include <android/log.h>
+#include <dlfcn.h>
 
 #include "llama.h"
 #include "ggml.h"
@@ -77,21 +78,51 @@ Java_com_theorangeshade_onenm_1local_1llm_OneNmNative_loadModel(
     // platform-specific backends (CPU, GPU, etc.) are discovered at runtime.
     LOGI("Initializing llama backend...");
     llama_log_set(llama_log_callback, nullptr);
-    ggml_backend_load_all_from_path(lib_dir);
-    LOGI("Backends loaded after path scan: %zu", ggml_backend_reg_count());
 
-    // Fallback: On some Android devices/apps, directory scanning fails silently
-    // (SELinux, path differences). Explicitly load the CPU backend by full path.
+    // Try 1: Scan the native lib directory for backend .so files.
+    ggml_backend_load_all_from_path(lib_dir);
+    LOGI("Backends after path scan: %zu", ggml_backend_reg_count());
+
+    // Try 2: System default discovery (may use different search paths).
     if (ggml_backend_reg_count() == 0) {
-        LOGI("Path scan found no backends, loading CPU backend explicitly...");
+        LOGI("Path scan found no backends, trying system default discovery...");
+        ggml_backend_load_all();
+        LOGI("Backends after system discovery: %zu", ggml_backend_reg_count());
+    }
+
+    // Try 3: Load CPU backend by just the filename. Since System.loadLibrary()
+    // in Kotlin already loaded the .so into the process, dlopen with just the
+    // filename should find it in the linker namespace.
+    if (ggml_backend_reg_count() == 0) {
+        LOGI("Trying to load CPU backend by filename only...");
+        const char * cpu_names[] = {
+            "libggml-cpu-android_armv8.2_1.so",
+            "libggml-cpu.so",
+        };
+        for (const char * name : cpu_names) {
+            ggml_backend_reg_t reg = ggml_backend_load(name);
+            if (reg) {
+                LOGI("CPU backend loaded via filename: %s", name);
+                break;
+            } else {
+                LOGI("Failed to load %s: %s", name, dlerror() ? dlerror() : "unknown");
+            }
+        }
+        LOGI("Backends after filename load: %zu", ggml_backend_reg_count());
+    }
+
+    // Try 4: Full path as last resort.
+    if (ggml_backend_reg_count() == 0) {
+        LOGI("Trying full path load...");
         std::string cpu_path = std::string(lib_dir) + "/libggml-cpu-android_armv8.2_1.so";
         ggml_backend_reg_t reg = ggml_backend_load(cpu_path.c_str());
         if (reg) {
-            LOGI("CPU backend loaded explicitly");
+            LOGI("CPU backend loaded via full path");
         } else {
-            LOGE("Failed to load CPU backend from: %s", cpu_path.c_str());
+            LOGE("All backend loading strategies failed. dlopen error: %s",
+                 dlerror() ? dlerror() : "unknown");
         }
-        LOGI("Backends loaded after explicit load: %zu", ggml_backend_reg_count());
+        LOGI("Backends after full path load: %zu", ggml_backend_reg_count());
     }
 
     llama_backend_init();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Flutter plugin for on-device LLM inference on Android using llama.cpp.
   Simplifies model management, loading, and multi-turn chat — no cloud,
   no API keys, fully offline.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/SxryxnshS5/onenm_local_llm
 issue_tracker: https://github.com/SxryxnshS5/onenm_local_llm/issues
 topics:


### PR DESCRIPTION
- Fixed native backend loading failing in consumer apps on Android 6+ (API 23+).
  Root cause: `extractNativeLibs` defaults to `false`, so `.so` files stay inside
  the APK and are never extracted to the `nativeLibraryDir` on disk. Added
  `android:extractNativeLibs="true"` to the plugin manifest so it merges into all
  consumer apps automatically.
- Improved backend loading with a 4-step fallback chain: directory scan → system
  default discovery → filename-only load → full-path load, with `dlerror()` logging
  for diagnostics.